### PR TITLE
feat: PreviewImage 컴포넌트 구현

### DIFF
--- a/src/components/all/TabBar.tsx
+++ b/src/components/all/TabBar.tsx
@@ -1,13 +1,13 @@
 import ComingSoon from '@public/svg/tabComingSoonIcon.svg';
 import DownLoads from '@public/svg/tabDownloadIcon.svg';
 import Home from '@public/svg/tabHomeIcon.svg';
-import Search from '@public/svg/tabHomeIcon.svg';
+import Search from '@public/svg/tabSearchIcon.svg';
 import More from '@public/svg/tabMoreIcon.svg';
 
 export default function TabBar() {
   return (
     <div className="w-full h-[79.7px] flex flex-col">
-      <div className="w-full h-[53px] flex justify-evenly items-center">
+      <div className="w-full h-[53px] flex justify-around items-center">
         <Home className="hover:cursor-pointer" />
         <Search className="hover:cursor-pointer" />
         <ComingSoon className="hover:cursor-pointer" />

--- a/src/components/main/PreviewImage.tsx
+++ b/src/components/main/PreviewImage.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+interface PreviewImageProps {
+  imageUrl: string;
+  square?: boolean;
+}
+
+export default function PreviewImage({
+  imageUrl,
+  square = false,
+}: PreviewImageProps) {
+  return (
+    <article
+      className={
+        square
+          ? 'w-[103px] h-[161px] overflow-hidden relative'
+          : 'w-[100px] h-[100px] rounded-full overflow-hidden relative'
+      }
+    >
+      <Image
+        alt="preview_image"
+        src={imageUrl}
+        objectFit="cover"
+        layout="fill"
+      />
+    </article>
+  );
+}


### PR DESCRIPTION
`TabBar` 수정했습니다.

`PreviewImage`컴포넌트 `props`로 `url`이랑 `square`여부 전달해주시면 됩니다.
```ts
interface PreviewImageProps {
  imageUrl: string;
  square?: boolean;
}

export default function PreviewImage({
  imageUrl,
  square = false,
}: PreviewImageProps) {
...
```
`square`는 `default`값으로 `false`를 사용하고 있어 원형 컴포넌트를 사용할때는 안쓰면 되고 사각형 컴포넌트를 사용할때 true 넘겨주시면 됩니다.
