### PR TITLE
feat: search 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-lottie-player": "^2.0.0",
+        "recoil": "^0.7.7",
         "sharp": "^0.33.3"
       },
       "devDependencies": {
@@ -5365,6 +5366,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -6926,6 +6932,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-lottie-player": "^2.0.0",
+    "recoil": "^0.7.7",
     "sharp": "^0.33.3"
   },
   "devDependencies": {

--- a/src/apis/getMovieNowPlaying.ts
+++ b/src/apis/getMovieNowPlaying.ts
@@ -1,7 +1,7 @@
 // 현재 상영 중인 영화 데이터를 반환하는 함수.
 export async function getMovieNowPlaying() {
   const previewMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/now_playing?api_key=${process.env.THEMOVIE_API_KEY}`,
+    `https://api.themoviedb.org/3/movie/now_playing?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
     { cache: 'no-store' }
   );
 
@@ -13,7 +13,7 @@ export async function getMovieNowPlaying() {
 // 인기 있는 영화 데이터를 반환하는 함수
 export async function getMoviePopular() {
   const popularMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.THEMOVIE_API_KEY}`,
+    `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
     { cache: 'no-store' }
   );
 
@@ -25,7 +25,7 @@ export async function getMoviePopular() {
 // top-rated 된 영화 데이터를 반환하는 함수 : 기본적으로 page 1에 해당하는 데이터 20개를 보여줌
 export async function getMovieTopRated() {
   const topRatedMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.THEMOVIE_API_KEY}`,
+    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
     { cache: 'no-store' }
   );
 
@@ -37,7 +37,7 @@ export async function getMovieTopRated() {
 // search page에서 스크롤을 내리면 계속 그 다음으로 유명한 영화 목록들을 끌어올 때 사용하는 함수
 export async function getMovieTopRatedByPageNumber(pageNumber: number) {
   const topRatedMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.THEMOVIE_API_KEY}&page=${pageNumber}`,
+    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}&page=${pageNumber}`,
     { cache: 'no-store' }
   );
 
@@ -48,7 +48,7 @@ export async function getMovieTopRatedByPageNumber(pageNumber: number) {
 
 export async function getMovieUpComing() {
   const upComingMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/upcoming?api_key=${process.env.THEMOVIE_API_KEY}`,
+    `https://api.themoviedb.org/3/movie/upcoming?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
     { cache: 'no-store' }
   );
 
@@ -61,7 +61,7 @@ export async function getMovieUpComing() {
 // 특정 영화 아이콘을 눌렀을 때 상세 정보 탭으로 이동하는 경우 이걸 사용해서 상세 페이지를 보여주면 될듯
 export async function getMovieInfoByMovieId(movieId: number) {
   const movieInfoResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/${movieId}?language=en-US&api_key=${process.env.THEMOVIE_API_KEY}`
+    `https://api.themoviedb.org/3/movie/${movieId}?language=en-US&api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`
   );
 
   return movieInfoResponse.json();

--- a/src/app/(CommonPageLayout)/search/page.tsx
+++ b/src/app/(CommonPageLayout)/search/page.tsx
@@ -7,7 +7,7 @@ export default async function SearchPage() {
   return (
     <section className="w-full h-full flex flex-col gap-5">
       <SearchInput />
-      <h1 className="text-[26px] leading-[20px] tracking-[-0.07px] p-[10px]">
+      <h1 className="text-[26px] leading-[20px] tracking-[-0.07px] p-[10px] font-bold">
         Top Searches
       </h1>
       <div className="flex flex-col w-full overflow-scroll gap-1 mb-[86px]">

--- a/src/app/(CommonPageLayout)/search/page.tsx
+++ b/src/app/(CommonPageLayout)/search/page.tsx
@@ -1,27 +1,14 @@
+import MovieSection from '@components/search/MovieSection';
 import SearchInput from '@components/search/SearchInput';
-import SearchMovieCard from '@components/search/SearchMovieCard';
-import useGetMovieImgAndTitle from '@hooks/useGetMovieImgAndTitle';
 
 export default async function SearchPage() {
-  const { getMovieTopRatedImgAndTitle } = await useGetMovieImgAndTitle();
   return (
     <section className="w-full h-full flex flex-col gap-5">
       <SearchInput />
       <h1 className="text-[26px] leading-[20px] tracking-[-0.07px] p-[10px] font-bold">
         Top Searches
       </h1>
-      <div className="flex flex-col w-full overflow-scroll gap-1 mb-[86px]">
-        {getMovieTopRatedImgAndTitle.map((movie, idx) => {
-          return (
-            <SearchMovieCard
-              key={idx}
-              poster_path={movie.poster_path}
-              title={movie.title}
-              id={movie.id}
-            />
-          );
-        })}
-      </div>
+      <MovieSection />
     </section>
   );
 }

--- a/src/app/(CommonPageLayout)/search/page.tsx
+++ b/src/app/(CommonPageLayout)/search/page.tsx
@@ -17,6 +17,7 @@ export default async function SearchPage() {
               key={idx}
               poster_path={movie.poster_path}
               title={movie.title}
+              id={movie.id}
             />
           );
         })}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import RecoilRootProvider from '@utils/RecoilRootProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,7 +21,9 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/icon/netflix.ico" type="image/x-icon" />
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <RecoilRootProvider>{children}</RecoilRootProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/search/MovieSection.tsx
+++ b/src/components/search/MovieSection.tsx
@@ -2,12 +2,18 @@
 import useGetMovieImgAndId from '@hooks/useGetMovieImg';
 import useGetMovieImgAndTitleAndId from '@hooks/useGetMovieImgAndTitle';
 import { showingMovie } from '@utils/showingMovieAtom';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 import SearchMovieCard from './SearchMovieCard';
+import { getMovieTopRatedByPageNumber } from '@apis/getMovieNowPlaying';
 
 export default function MovieSection() {
+  const loaderRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [number, setNumber] = useState(2);
+
   const [showingMovies, setShowingMovies] = useRecoilState(showingMovie);
+
   useEffect(() => {
     async function fetchMovieData() {
       const { getMovieTopRatedImgAndTitle } =
@@ -15,19 +21,58 @@ export default function MovieSection() {
       setShowingMovies(getMovieTopRatedImgAndTitle);
     }
     fetchMovieData();
-  }, []);
+  }, [setShowingMovies]);
+
+  const loadMore = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await getMovieTopRatedByPageNumber(number);
+      const newMovies = res.map((movie: any) => ({
+        poster_path: movie.poster_path,
+        title: movie.title,
+        id: movie.id,
+      }));
+      setShowingMovies((prev) => [...prev, ...newMovies]);
+      setNumber((prev) => prev + 1);
+    } catch (error) {
+      console.error('Failed to load more movies', error);
+    } finally {
+      setIsLoading(false); // Reset loading state
+    }
+  }, [number, setShowingMovies]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        const firstEntry = entries[0];
+        if (firstEntry.isIntersecting && !isLoading) {
+          loadMore();
+        }
+      }
+    );
+
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current);
+    }
+
+    return () => {
+      if (loaderRef.current) {
+        observer.unobserve(loaderRef.current);
+      }
+    };
+  }, [isLoading, loadMore]);
+
   return (
     <div className="flex flex-col w-full overflow-scroll gap-1 mb-[86px]">
-      {showingMovies.map((movie, idx) => {
-        return (
-          <SearchMovieCard
-            key={idx}
-            poster_path={movie.poster_path}
-            title={movie.title}
-            id={movie.id}
-          />
-        );
-      })}
+      {showingMovies.map((movie, idx) => (
+        <SearchMovieCard
+          key={idx}
+          poster_path={movie.poster_path}
+          title={movie.title}
+          id={movie.id}
+        />
+      ))}
+      <div ref={loaderRef}></div>
     </div>
   );
 }

--- a/src/components/search/MovieSection.tsx
+++ b/src/components/search/MovieSection.tsx
@@ -1,0 +1,33 @@
+'use client';
+import useGetMovieImgAndId from '@hooks/useGetMovieImg';
+import useGetMovieImgAndTitleAndId from '@hooks/useGetMovieImgAndTitle';
+import { showingMovie } from '@utils/showingMovieAtom';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import SearchMovieCard from './SearchMovieCard';
+
+export default function MovieSection() {
+  const [showingMovies, setShowingMovies] = useRecoilState(showingMovie);
+  useEffect(() => {
+    async function fetchMovieData() {
+      const { getMovieTopRatedImgAndTitle } =
+        await useGetMovieImgAndTitleAndId();
+      setShowingMovies(getMovieTopRatedImgAndTitle);
+    }
+    fetchMovieData();
+  }, []);
+  return (
+    <div className="flex flex-col w-full overflow-scroll gap-1 mb-[86px]">
+      {showingMovies.map((movie, idx) => {
+        return (
+          <SearchMovieCard
+            key={idx}
+            poster_path={movie.poster_path}
+            title={movie.title}
+            id={movie.id}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/search/SearchInput.tsx
+++ b/src/components/search/SearchInput.tsx
@@ -3,14 +3,14 @@ import Close from '@public/svg/close.svg';
 
 export default function SearchInput() {
   return (
-    <section className="w-full h-[52px] flex items-center gap-5 px-5 bg-[#424242] mt-[52px]">
-      <Search />
+    <section className="w-full h-[52px] flex items-center gap-5 px-5 bg-[#424242] mt-[52px] shrink-0">
+      <Search className="shrink-0" />
       <input
         type="text"
         placeholder="Search for a show, movie, genre, e.t.c."
-        className="w-full bg-[#424242]"
+        className="w-full bg-[#424242] no-underline outline-none"
       />
-      <Close />
+      <Close className="shrink-0" />
     </section>
   );
 }

--- a/src/components/search/SearchInput.tsx
+++ b/src/components/search/SearchInput.tsx
@@ -1,14 +1,45 @@
+'use client';
 import Search from '@public/svg/search.svg';
 import Close from '@public/svg/close.svg';
+import { useRecoilState } from 'recoil';
+import { showingMovie } from '@utils/showingMovieAtom';
+import { useEffect, useState } from 'react';
 
 export default function SearchInput() {
+  const [showingMovies, setShowingMovies] = useRecoilState(showingMovie);
+  console.log('showingMovies', showingMovies);
+  const [allMovies, setAllMovies] = useState(showingMovies);
+  useEffect(() => {
+    if (showingMovies.length > 0 && allMovies.length === 0) {
+      setAllMovies(showingMovies);
+    }
+  }, [showingMovies]);
+  console.log('allMovies', allMovies);
+  const HandleInput = () => {
+    const searchInput = document.querySelector<HTMLInputElement>('#input');
+    if (searchInput) {
+      const searchValue = searchInput.value;
+      console.log('searchValue', searchValue);
+      const searchResult = showingMovies.filter((movie) => {
+        return movie.title.includes(searchValue);
+      });
+
+      if (searchValue === '') {
+        setShowingMovies(allMovies);
+      } else {
+        setShowingMovies(searchResult);
+      }
+    } else setShowingMovies(allMovies);
+  };
   return (
     <section className="w-full h-[52px] flex items-center gap-5 px-5 bg-[#424242] mt-[52px] shrink-0">
       <Search className="shrink-0" />
       <input
         type="text"
+        id="input"
         placeholder="Search for a show, movie, genre, e.t.c."
         className="w-full bg-[#424242] no-underline outline-none"
+        onChange={HandleInput}
       />
       <Close className="shrink-0" />
     </section>

--- a/src/components/search/SearchInput.tsx
+++ b/src/components/search/SearchInput.tsx
@@ -7,14 +7,12 @@ import { useEffect, useState } from 'react';
 
 export default function SearchInput() {
   const [showingMovies, setShowingMovies] = useRecoilState(showingMovie);
-  console.log('showingMovies', showingMovies);
   const [allMovies, setAllMovies] = useState(showingMovies);
   useEffect(() => {
     if (showingMovies.length > 0 && allMovies.length === 0) {
       setAllMovies(showingMovies);
     }
   }, [showingMovies]);
-  console.log('allMovies', allMovies);
   const HandleInput = () => {
     const searchInput = document.querySelector<HTMLInputElement>('#input');
     if (searchInput) {

--- a/src/components/search/SearchMovieCard.tsx
+++ b/src/components/search/SearchMovieCard.tsx
@@ -1,17 +1,23 @@
 import Image from 'next/image';
 import PlayCircle from '@public/svg/playCircle.svg';
+import Link from 'next/link';
 
 interface SearchMovieCardProps {
   poster_path: string;
   title: string;
+  id: string;
 }
 
 export default function SearchMovieCard({
   poster_path,
   title,
+  id,
 }: SearchMovieCardProps) {
   return (
-    <article className="w-full h-[76px] flex bg-[#424242]">
+    <Link
+      className="w-full h-[76px] flex bg-[#424242] cursor-pointer"
+      href={`/movie-detail/${id}`}
+    >
       <div className="w-[146px] h-[76px] overflow-hidden relative shrink-0">
         <Image
           src={`https://image.tmdb.org/t/p/w1280${poster_path}`}
@@ -24,6 +30,6 @@ export default function SearchMovieCard({
         <span className="text-[14px] leading-[30px]">{title}</span>
         <PlayCircle className="shrink-0" />
       </div>
-    </article>
+    </Link>
   );
 }

--- a/src/components/search/SearchMovieCard.tsx
+++ b/src/components/search/SearchMovieCard.tsx
@@ -22,7 +22,7 @@ export default function SearchMovieCard({
       </div>
       <div className="flex p-3 justify-between items-center w-full">
         <span className="text-[14px] leading-[30px]">{title}</span>
-        <PlayCircle />
+        <PlayCircle className="shrink-0" />
       </div>
     </article>
   );

--- a/src/components/search/SearchMovieCard.tsx
+++ b/src/components/search/SearchMovieCard.tsx
@@ -24,6 +24,7 @@ export default function SearchMovieCard({
           alt={title}
           fill
           className="object-cover"
+          sizes="(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 100vw, 146px"
         />
       </div>
       <div className="flex p-3 justify-between items-center w-full">

--- a/src/hooks/useGetMovieImgAndTitle.tsx
+++ b/src/hooks/useGetMovieImgAndTitle.tsx
@@ -1,11 +1,15 @@
 import { getMovieTopRated } from '@apis/getMovieNowPlaying';
 
-export default async function useGetMovieImgAndTitle() {
-  const getMovieTopRatedImgAndTitle: { poster_path: string; title: string }[] =
-    (await getMovieTopRated()).map((movie: any) => ({
-      poster_path: movie.poster_path,
-      title: movie.title,
-    }));
+export default async function useGetMovieImgAndTitleAndId() {
+  const getMovieTopRatedImgAndTitle: {
+    poster_path: string;
+    title: string;
+    id: string;
+  }[] = (await getMovieTopRated()).map((movie: any) => ({
+    poster_path: movie.poster_path,
+    title: movie.title,
+    id: movie.id,
+  }));
   return {
     getMovieTopRatedImgAndTitle,
   };

--- a/src/hooks/useGetMovieImgAndTitle.tsx
+++ b/src/hooks/useGetMovieImgAndTitle.tsx
@@ -12,4 +12,5 @@ export default async function useGetMovieImgAndTitleAndId() {
   return {
     getMovieTopRatedImgAndTitle,
   };
+  
 }

--- a/src/hooks/useGetMovieImgAndTitle.tsx
+++ b/src/hooks/useGetMovieImgAndTitle.tsx
@@ -1,11 +1,10 @@
 import { getMovieTopRated } from '@apis/getMovieNowPlaying';
+import { movieInfowithTitle } from 'types/movie';
 
 export default async function useGetMovieImgAndTitleAndId() {
-  const getMovieTopRatedImgAndTitle: {
-    poster_path: string;
-    title: string;
-    id: string;
-  }[] = (await getMovieTopRated()).map((movie: any) => ({
+  const getMovieTopRatedImgAndTitle: movieInfowithTitle[] = (
+    await getMovieTopRated()
+  ).map((movie: any) => ({
     poster_path: movie.poster_path,
     title: movie.title,
     id: movie.id,

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,0 +1,10 @@
+export interface movieInfo {
+  posterPath: string;
+  movieId: number;
+}
+
+export interface movieInfowithTitle {
+  poster_path: string;
+  title: string;
+  id: string;
+}

--- a/src/types/movie.tsx
+++ b/src/types/movie.tsx
@@ -1,4 +1,0 @@
-export interface movieInfo {
-  posterPath: string;
-  movieId: number;
-}

--- a/src/utils/RecoilRootProvider.tsx
+++ b/src/utils/RecoilRootProvider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { RecoilRoot } from 'recoil';
+export default function RecoilRootProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <RecoilRoot>{children}</RecoilRoot>;
+}

--- a/src/utils/showingMovieAtom.ts
+++ b/src/utils/showingMovieAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { movieInfowithTitle } from 'types/movie';
+
+export const showingMovieAtom = atom<movieInfowithTitle[]>({
+  key: 'showingMovie',
+  default: [],
+});

--- a/src/utils/showingMovieAtom.ts
+++ b/src/utils/showingMovieAtom.ts
@@ -5,3 +5,8 @@ export const showingMovie = atom<movieInfowithTitle[]>({
   key: 'showingMovie',
   default: [],
 });
+
+export const showingMovieCopy = atom<movieInfowithTitle[]>({
+  key: 'showingMovieCopy',
+  default: [],
+});

--- a/src/utils/showingMovieAtom.ts
+++ b/src/utils/showingMovieAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { movieInfowithTitle } from 'types/movie';
 
-export const showingMovieAtom = atom<movieInfowithTitle[]>({
+export const showingMovie = atom<movieInfowithTitle[]>({
   key: 'showingMovie',
   default: [],
 });


### PR DESCRIPTION
검색기능과 무한스크롤 구현했습니다.
검색기능은 `recoil`설치하여 구현했고 `MovieSection`컴포넌트, `SearchInput`컴포넌트만 클라이언트 컴포넌트로 선언하여 만들었습니다.
라이브러리를 사용하지 않고 무한스크롤을 구현하려 했더니 성능이 너무 구데기.. 같습니다.
클라이언트컴포넌트를 통해 구현하다 보니 APIKEY가 클라이언트에 노출되는데 해결책을 못 찾았습니다.