### PR TITLE
자잘한 Image 관련 속성 수정 & 중요한 api key 노출 사항 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ yarn-error.log*
 next-env.d.ts
 node_modules
 
-.env
+.env*

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,41 @@ const nextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/nowPlayingmovies',
+        destination: `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+      },
+      {
+        source: '/api/popularMovies',
+        destination: `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+      },
+      {
+        source: `/api/topRatedMovies`,
+        destination: `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+      },
+      {
+        source: `/api/topRatedMoviesByPage`,
+        has: [
+          {
+            type: 'query',
+            key: 'pageNumber',
+            value: '(?<pageNumber>.*)',
+          },
+        ],
+        destination: `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}&page=:pageNumber`,
+      },
+      {
+        source: '/api/upComingMovies',
+        destination: `https://api.themoviedb.org/3/movie/upcoming?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+      },
+      {
+        source: '/api/movieInfo/:path*',
+        destination: `https://api.themoviedb.org/3/movie/:path*?language=en-US&api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "start:dev": "next start -p 3000",
+    "start:prod:local": "NODE_ENV=production next start -p 4000",
+    "start:prod": "NODE_ENV=production next start -p 8080",
     "lint": "next lint"
   },
   "dependencies": {

--- a/src/apis/getMovieNowPlaying.ts
+++ b/src/apis/getMovieNowPlaying.ts
@@ -1,8 +1,12 @@
+const domainName = process.env.NEXT_PUBLIC_DOMAIN_NAME;
+
 // 현재 상영 중인 영화 데이터를 반환하는 함수.
 export async function getMovieNowPlaying() {
   const previewMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/now_playing?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
-    { cache: 'no-store' }
+    `${domainName}/api/nowPlayingmovies`,
+    {
+      cache: 'no-store',
+    }
   );
 
   const previewMovieData = await previewMovieResponse.json();
@@ -12,10 +16,9 @@ export async function getMovieNowPlaying() {
 
 // 인기 있는 영화 데이터를 반환하는 함수
 export async function getMoviePopular() {
-  const popularMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/popular?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
-    { cache: 'no-store' }
-  );
+  const popularMovieResponse = await fetch(`${domainName}/api/popularMovies`, {
+    cache: 'no-store',
+  });
 
   const popularMovieData = await popularMovieResponse.json();
 
@@ -25,7 +28,7 @@ export async function getMoviePopular() {
 // top-rated 된 영화 데이터를 반환하는 함수 : 기본적으로 page 1에 해당하는 데이터 20개를 보여줌
 export async function getMovieTopRated() {
   const topRatedMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+    `${domainName}/api/topRatedMovies`,
     { cache: 'no-store' }
   );
 
@@ -37,7 +40,7 @@ export async function getMovieTopRated() {
 // search page에서 스크롤을 내리면 계속 그 다음으로 유명한 영화 목록들을 끌어올 때 사용하는 함수
 export async function getMovieTopRatedByPageNumber(pageNumber: number) {
   const topRatedMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/top_rated?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}&page=${pageNumber}`,
+    `${domainName}/api/topRatedMoviesByPage?pageNumber=${pageNumber}`,
     { cache: 'no-store' }
   );
 
@@ -48,7 +51,7 @@ export async function getMovieTopRatedByPageNumber(pageNumber: number) {
 
 export async function getMovieUpComing() {
   const upComingMovieResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/upcoming?api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`,
+    `${domainName}/api/upComingMovies`,
     { cache: 'no-store' }
   );
 
@@ -61,7 +64,7 @@ export async function getMovieUpComing() {
 // 특정 영화 아이콘을 눌렀을 때 상세 정보 탭으로 이동하는 경우 이걸 사용해서 상세 페이지를 보여주면 될듯
 export async function getMovieInfoByMovieId(movieId: number) {
   const movieInfoResponse = await fetch(
-    `https://api.themoviedb.org/3/movie/${movieId}?language=en-US&api_key=${process.env.NEXT_PUBLIC_THEMOVIE_API_KEY}`
+    `${domainName}/api/movieInfo/${movieId}`
   );
 
   return movieInfoResponse.json();

--- a/src/components/main/PreviewImage.tsx
+++ b/src/components/main/PreviewImage.tsx
@@ -13,14 +13,14 @@ export default function PreviewImage({
   movieId,
 }: PreviewImageProps) {
   return (
-    <article
-      className={
-        square
-          ? 'w-[103px] h-[161px] overflow-hidden relative shrink-0'
-          : 'w-[100px] h-[100px] rounded-full overflow-hidden relative shrink-0'
-      }
-    >
-      <Link href={`/movie-detail/${movieId}`}>
+    <Link href={`/movie-detail/${movieId}`}>
+      <article
+        className={
+          square
+            ? 'w-[103px] h-[161px] overflow-hidden relative shrink-0'
+            : 'w-[100px] h-[100px] rounded-full overflow-hidden relative shrink-0'
+        }
+      >
         <Image
           alt="preview_image"
           src={imageUrl}
@@ -28,7 +28,7 @@ export default function PreviewImage({
           className="object-cover"
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         />
-      </Link>
-    </article>
+      </article>
+    </Link>
   );
 }

--- a/src/components/movie-detail/ThumbNailImage.tsx
+++ b/src/components/movie-detail/ThumbNailImage.tsx
@@ -12,6 +12,7 @@ export default function ThumbNailImage({ imageUrl }: ThumbNailImageProp) {
         src={imageUrl}
         fill
         className="object-cover"
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
       />
       ;
     </article>

--- a/src/components/search/MovieSection.tsx
+++ b/src/components/search/MovieSection.tsx
@@ -1,5 +1,4 @@
 'use client';
-import useGetMovieImgAndId from '@hooks/useGetMovieImg';
 import useGetMovieImgAndTitleAndId from '@hooks/useGetMovieImgAndTitle';
 import { showingMovie } from '@utils/showingMovieAtom';
 import { useEffect, useRef, useState, useCallback } from 'react';


### PR DESCRIPTION
1. 기존의 **Image** 컴포넌트를 누르면 `/movie-detail` 페이지로 이동 시에 Image 컴포넌트에 fill 속성을 써서 그 부모가 relative를 가져야하는 것이 꼬이는 현상 -> `Link` 컴포넌트가 article 컴포넌트를 감쌈으로서 해결 => 이번 PR에서 이건 걍 대충 무시해도 됨
2. `/main` 페이지는 서버 컴포넌트라 api key가 노출되는 일이 없었는데, `/search` 페이지의 **MovieSection**은 클라이언트 컴포넌트라 api key가 노출되는 일이 발생했음 -> **next.config.js** 설정 파일의 `rewrites()` 함수를 통해 요청 api 엔드포인트를 마스킹 함. 
3. 마스킹을 하니 기존의 fetch() 함수에서는 실제 외부 api url을 다 적어주었는데, 이제는 `/api/blabla` 만 적어줘도 되는 줄 알았음. 근데 node 18 이상 버전부터는 이를 full로 다 적어줘야 한다고 함. 근데 개발환경(**http://localhost:3000**) 과 실제 배포 환경에서는 다르잖슴? 그래서 `.env`, `.env.producton`, `.env.production.local`, `.env.development` 환경 파일에서 각각 환경변수 파일을 만들어주고 .gitignore에 넣어주었음 => 이건 공유해줄께!
4. 따라서 관련 npm script 명령어도 좀 바뀌었음. 기존처럼 개발환경 실행은 npm run dev, 개발환경에서의 배포 테스트는 npm run build하고 npm run start:prod:local임
5. [배포링크](https://next-js-songess-seungwan.vercel.app/)인데 한번 api key /search 페이지에서 노출되는지 확인하고, 문제 있으면 카톡 ㄱㄱ

.env 관련 파일들은 카톡으로 공유할게!