### PR TITLE
fix: 무한스크롤 API호출 SSR 방식으로 변경

### DIFF
--- a/src/apis/getMovieNowPlaying.ts
+++ b/src/apis/getMovieNowPlaying.ts
@@ -41,7 +41,7 @@ export async function getMovieTopRated() {
 export async function getMovieTopRatedByPageNumber(pageNumber: number) {
   const topRatedMovieResponse = await fetch(
     `${domainName}/api/topRatedMoviesByPage?pageNumber=${pageNumber}`,
-    { cache: 'force-cache' }
+    { cache: 'no-store' }
   );
 
   const topRatedMovieData = await topRatedMovieResponse.json();

--- a/src/components/search/MovieSection.tsx
+++ b/src/components/search/MovieSection.tsx
@@ -5,30 +5,6 @@ import { useRecoilState } from 'recoil';
 import SearchMovieCard from './SearchMovieCard';
 import { getMovieTopRatedByPageNumber } from '@apis/getMovieNowPlaying';
 
-export async function generateStaticParams() {
-  return [
-    { number: '1' },
-    { number: '2' },
-    { number: '3' },
-    { number: '4' },
-    { number: '5' },
-    { number: '6' },
-    { number: '7' },
-    { number: '8' },
-    { number: '9' },
-    { number: '10' },
-    { number: '11' },
-    { number: '12' },
-    { number: '13' },
-    { number: '15' },
-    { number: '16' },
-    { number: '17' },
-    { number: '18' },
-    { number: '19' },
-    { number: '20' },
-  ];
-}
-
 export default function MovieSection() {
   const loaderRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);


### PR DESCRIPTION
무한스크롤 API 호출형식이 SSG 방식으로 올바르게 작동하지 않음에 따라 SSR 방식으로 변경했습니다.